### PR TITLE
IOF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 db.sqlite3
 .coverage
+
 PLAN.md
 DEVELOPER_NOTES.md
+IOF_CALCULATION_RULES.md
+
 htmlcov/
 .env
 .venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [0.5.0] - Step 4 - IOF (Imposto sobre Operações Financeiras) Implementation
+
+### Added
+- **IOFCalculatorService**: Calculates IOF (fixed rate 0.38% + daily rate 0.0082% per day, capped at 3% per year)
+- **IOF integration**: IOF included in outstanding balance calculation
+- **IOF field**: Added `iof` field to `LoanSerializer` (retrieve only)
+- **IOF tests**: Comprehensive test coverage for IOF calculation service
+
+### Changed
+- `OutstandingBalanceCalculatorService`: Now includes IOF in balance calculation
+- Outstanding balance formula: `(Principal + Interest + IOF) - Total Paid`
+- Updated existing tests to account for IOF in calculations
+
 ## [0.4.0] - Step 3 - Business Rules & Comprehensive Testing
 
 ### Added

--- a/apps/loans/serializers.py
+++ b/apps/loans/serializers.py
@@ -7,6 +7,7 @@ from apps.core.serializers.mixins.audit_serializer_mixin import (
 )
 from apps.core.serializers.user_serializer import UserSerializer
 from apps.loans.models import Loan
+from apps.loans.services.iof_calculator_svc import IOFCalculatorService
 from apps.loans.services.payment_aggregator_svc import PaymentAggregatorService
 from apps.loans.use_cases.calculate_loan_outstanding_balance_use_case import (
     CalculateLoanOutstandingBalanceUseCase,
@@ -17,6 +18,7 @@ class LoanSerializer(serializers.ModelSerializer, AuditSerializerMixin):
     owner = serializers.HiddenField(default=serializers.CurrentUserDefault())
     total_paid = serializers.SerializerMethodField()
     remaining_balance = serializers.SerializerMethodField()
+    iof = serializers.SerializerMethodField()
 
     critical_fields = ["owner", "bank", "amount", "interest_rate"]
 
@@ -39,6 +41,7 @@ class LoanSerializer(serializers.ModelSerializer, AuditSerializerMixin):
         self.outstanding_balance_use_case = (
             CalculateLoanOutstandingBalanceUseCase()
         )
+        self.iof_calculator = IOFCalculatorService()
 
         self._manage_critical_fields()
 
@@ -50,6 +53,11 @@ class LoanSerializer(serializers.ModelSerializer, AuditSerializerMixin):
         """Calculate outstanding balance (saldo devedor) for the loan."""
         balance = self.outstanding_balance_use_case.execute(obj)
         return float(balance)
+
+    def get_iof(self, obj):
+        """Calculate total IOF (fixed + daily) for the loan."""
+        total_iof = self.iof_calculator.calculate_total_iof(obj)
+        return float(total_iof)
 
     def get_request_ip(self):
         """Get the request IP from the context."""

--- a/apps/loans/services/iof_calculator_svc.py
+++ b/apps/loans/services/iof_calculator_svc.py
@@ -1,0 +1,107 @@
+from datetime import date
+from decimal import Decimal
+
+from apps.core.services.base.base_service import BaseService
+from apps.loans.models import Loan
+
+
+class IOFCalculatorService(BaseService):
+    """Service for calculating IOF (Imposto sobre Operações Financeiras)."""
+
+    # IOF rates for pessoa física (individual)
+    FIXED_RATE = Decimal("0.0038")  # 0.38%
+    DAILY_RATE = Decimal("0.000082")  # 0.0082% per day
+    ANNUAL_LIMIT = Decimal("0.03")  # 3% per year (365 days)
+
+    def calculate_fixed_iof(self, loan_amount: Decimal) -> Decimal:
+        """
+        Calculate fixed IOF (0.38% of loan amount).
+
+        Args:
+            loan_amount: The original loan amount
+
+        Returns:
+            The fixed IOF amount
+        """
+        fixed_iof = loan_amount * self.FIXED_RATE
+
+        self.logger.debug(
+            f"Fixed IOF calculated: loan_amount={loan_amount}, "
+            f"rate={self.FIXED_RATE}, result={fixed_iof}"
+        )
+        return fixed_iof
+
+    def calculate_daily_iof(
+        self, loan: Loan, reference_date: date = None
+    ) -> Decimal:
+        """
+        Calculate daily IOF (Imposto sobre Operações Financeiras).
+        (0.0082% per day on original amount, capped at 3% per year).
+
+        Args:
+            loan: The loan instance
+            reference_date: Date to calculate IOF as of (defaults to today)
+
+        Returns:
+            The daily IOF amount (capped at 3% of loan amount per year)
+        """
+        if reference_date is None:
+            reference_date = date.today()
+
+        # Calculate days between request_date and reference_date
+        days = self._calculate_days(loan.request_date, reference_date)
+
+        # Calculate daily IOF: 0.0082% per day on original amount
+        daily_iof_unlimited = loan.amount * self.DAILY_RATE * Decimal(days)
+
+        # Apply annual limit: maximum 3% of loan amount per year
+        annual_limit = loan.amount * self.ANNUAL_LIMIT
+        daily_iof = min(daily_iof_unlimited, annual_limit)
+
+        self.logger.debug(
+            f"Daily IOF calculated for loan {loan.uuid}: "
+            f"amount={loan.amount}, days={days}, "
+            f"unlimited={daily_iof_unlimited}, limit={annual_limit}, "
+            f"result={daily_iof}"
+        )
+        return daily_iof
+
+    def calculate_total_iof(
+        self, loan: Loan, reference_date: date = None
+    ) -> Decimal:
+        """
+        Calculate total IOF (fixed + daily).
+
+        Args:
+            loan: The loan instance
+            reference_date: Date to calculate IOF as of (defaults to today)
+
+        Returns:
+            The total IOF amount
+        """
+        fixed_iof = self.calculate_fixed_iof(loan.amount)
+        daily_iof = self.calculate_daily_iof(loan, reference_date)
+        total_iof = fixed_iof + daily_iof
+
+        self.logger.debug(
+            f"Total IOF calculated for loan {loan.uuid}: "
+            f"fixed={fixed_iof}, daily={daily_iof}, total={total_iof}"
+        )
+        return total_iof
+
+    def _calculate_days(self, start_date: date, end_date: date) -> int:
+        """
+        Calculate the number of days between two dates.
+
+        Args:
+            start_date: Start date
+            end_date: End date
+
+        Returns:
+            Number of days (0 if end_date is before start_date)
+        """
+        if end_date < start_date:
+            return 0
+
+        delta = end_date - start_date
+        return delta.days

--- a/apps/loans/services/outstanding_balance_calculator_svc.py
+++ b/apps/loans/services/outstanding_balance_calculator_svc.py
@@ -8,6 +8,7 @@ from apps.loans.models import Loan
 from apps.loans.services.interest_calculator_svc import (
     InterestCalculatorService,
 )
+from apps.loans.services.iof_calculator_svc import IOFCalculatorService
 from apps.loans.services.payment_aggregator_svc import PaymentAggregatorService
 
 
@@ -18,6 +19,7 @@ class OutstandingBalanceCalculatorService(BaseService):
         self,
         interest_calculator: InterestCalculatorService = None,
         payment_aggregator: PaymentAggregatorService = None,
+        iof_calculator: IOFCalculatorService = None,
     ):
         """
         Initialize the service with dependencies.
@@ -25,6 +27,7 @@ class OutstandingBalanceCalculatorService(BaseService):
         Args:
             interest_calculator: Service for calculating interest (injected)
             payment_aggregator: Service for aggregating payments (injected)
+            iof_calculator: Service for calculating IOF (injected)
         """
         super().__init__()
         self.interest_calculator = (
@@ -33,12 +36,13 @@ class OutstandingBalanceCalculatorService(BaseService):
         self.payment_aggregator = (
             payment_aggregator or PaymentAggregatorService()
         )
+        self.iof_calculator = iof_calculator or IOFCalculatorService()
 
     def calculate(self, loan: Loan, reference_date: date = None) -> Decimal:
         """
         Calculate the outstanding balance for a loan.
 
-        Formula: (Principal + Interest) - Total Paid
+        Formula: (Principal + Interest + IOF) - Total Paid
         If result is negative, returns 0 (no negative balance allowed).
 
         Args:
@@ -63,18 +67,24 @@ class OutstandingBalanceCalculatorService(BaseService):
             )
         )
 
+        # Calculate IOF (fixed + daily)
+        total_iof = self.iof_calculator.calculate_total_iof(
+            loan, reference_date
+        )
+
         # Get total paid
         total_paid = self.payment_aggregator.get_total_paid(loan)
 
-        # Calculate outstanding balance (minimum 0)
-        outstanding_balance = amount_with_interest - total_paid
+        # Calculate outstanding balance:
+        # (Principal + Interest + IOF) - Total Paid
+        outstanding_balance = amount_with_interest + total_iof - total_paid
         result = max(Decimal("0.00"), outstanding_balance)
 
         self.logger.debug(
             f"Outstanding balance calculated for loan {loan.uuid}: "
             f"amount={loan.amount}, months={months}, "
             f"amount_with_interest={amount_with_interest}, "
-            f"total_paid={total_paid}, result={result}"
+            f"total_iof={total_iof}, total_paid={total_paid}, result={result}"
         )
         return result
 

--- a/apps/loans/tests/test_calculate_loan_outstanding_balance_use_case.py
+++ b/apps/loans/tests/test_calculate_loan_outstanding_balance_use_case.py
@@ -79,5 +79,16 @@ def test_execute_returns_calculator_result(use_case):
     result = use_case.execute(loan)
 
     # Assert
-    # Should calculate correctly: 10000 * (1.025)^2 = 10506.25
-    assert result == Decimal("10506.25")
+    # Should calculate correctly:
+    # (10000 * (1.025)^2) + IOF = 10506.25 + 87.20 = 10593.45
+    # IOF: Fixed (38.00) + Daily (60 days * 0.0082% = 49.20) = 87.20
+    amount_with_interest = (
+        Decimal("10000.00") * (Decimal("1") + Decimal("0.025")) ** 2
+    )
+    iof_fixed = Decimal("10000.00") * Decimal("0.0038")  # 38.00
+    iof_daily = (
+        Decimal("10000.00") * Decimal("0.000082") * Decimal("60")
+    )  # 49.20
+    total_iof = iof_fixed + iof_daily
+    expected = amount_with_interest + total_iof
+    assert result == expected

--- a/apps/loans/tests/test_iof_calculator_svc.py
+++ b/apps/loans/tests/test_iof_calculator_svc.py
@@ -1,0 +1,227 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from freezegun import freeze_time
+
+from apps.core.tests.factories.loan import LoanFactory
+from apps.loans.services.iof_calculator_svc import IOFCalculatorService
+
+
+@pytest.fixture
+def iof_calculator():
+    """Fixture for IOFCalculatorService."""
+    return IOFCalculatorService()
+
+
+@pytest.mark.django_db
+def test_calculate_fixed_iof(iof_calculator):
+    """Test fixed IOF calculation (0.38% of loan amount)."""
+    # Arrange
+    loan_amount = Decimal("10000.00")
+
+    # Act
+    result = iof_calculator.calculate_fixed_iof(loan_amount)
+
+    # Assert
+    expected = loan_amount * Decimal("0.0038")
+    assert result == expected
+    assert result == Decimal("38.00")
+
+
+@pytest.mark.django_db
+def test_calculate_fixed_iof_different_amount(iof_calculator):
+    """Test fixed IOF calculation with different amount."""
+    # Arrange
+    loan_amount = Decimal("5000.00")
+
+    # Act
+    result = iof_calculator.calculate_fixed_iof(loan_amount)
+
+    # Assert
+    expected = loan_amount * Decimal("0.0038")
+    assert result == expected
+    assert result == Decimal("19.00")
+
+
+@pytest.mark.django_db
+@freeze_time("2024-07-01")
+def test_calculate_daily_iof_30_days(iof_calculator):
+    """Test daily IOF calculation for 30 days."""
+    # Arrange
+    loan = LoanFactory(
+        amount=Decimal("10000.00"),
+        request_date=date(2024, 6, 1),
+    )
+
+    # Act
+    result = iof_calculator.calculate_daily_iof(loan)
+
+    # Assert
+    # 30 days * 0.0082% = 0.246% of 10000 = 24.60
+    expected = Decimal("10000.00") * Decimal("0.000082") * Decimal("30")
+    assert result == expected
+    assert result == Decimal("24.60")
+
+
+@pytest.mark.django_db
+@freeze_time("2024-06-29")
+def test_calculate_daily_iof_180_days(iof_calculator):
+    """Test daily IOF calculation for 180 days."""
+    # Arrange
+    loan = LoanFactory(
+        amount=Decimal("10000.00"),
+        request_date=date(2024, 1, 1),
+    )
+
+    # Act
+    result = iof_calculator.calculate_daily_iof(loan)
+
+    # Assert
+    # 180 days * 0.0082% = 1.476% of 10000 = 147.60
+    expected = Decimal("10000.00") * Decimal("0.000082") * Decimal("180")
+    assert result == expected
+    assert result == Decimal("147.60")
+
+
+@pytest.mark.django_db
+@freeze_time("2025-01-01")
+def test_calculate_daily_iof_365_days_at_limit(iof_calculator):
+    """Test daily IOF calculation at annual limit
+    (366 days in 2024, limit applies).
+    """
+    # Arrange
+    loan = LoanFactory(
+        amount=Decimal("10000.00"),
+        request_date=date(2024, 1, 1),
+    )
+
+    # Act
+    result = iof_calculator.calculate_daily_iof(loan)
+
+    # Assert
+    # 366 days (2024 is leap year) * 0.0082% = 3.0012% of 10000 = 300.12
+    # But limit is 3% = 300.00, so result should be capped at 300.00
+    limit = Decimal("10000.00") * Decimal("0.03")
+    assert result == limit
+    assert result == Decimal("300.00")
+
+
+@pytest.mark.django_db
+@freeze_time("2025-07-01")
+def test_calculate_daily_iof_exceeds_annual_limit(iof_calculator):
+    """Test daily IOF calculation when days exceed annual limit."""
+    # Arrange
+    loan = LoanFactory(
+        amount=Decimal("10000.00"),
+        request_date=date(2024, 1, 1),
+    )
+
+    # Act
+    result = iof_calculator.calculate_daily_iof(loan)
+
+    # Assert
+    # 545 days * 0.0082% = 4.469% of 10000 = 446.90
+    # But limit is 3% = 300.00, so result should be capped at 300.00
+    annual_limit = Decimal("10000.00") * Decimal("0.03")
+    assert result == annual_limit
+    assert result == Decimal("300.00")
+
+
+@pytest.mark.django_db
+@freeze_time("2024-01-15")
+def test_calculate_daily_iof_same_day_returns_zero(iof_calculator):
+    """Test daily IOF calculation for same day returns zero."""
+    # Arrange
+    loan = LoanFactory(
+        amount=Decimal("10000.00"),
+        request_date=date(2024, 1, 15),
+    )
+
+    # Act
+    result = iof_calculator.calculate_daily_iof(loan)
+
+    # Assert
+    assert result == Decimal("0.00")
+
+
+@pytest.mark.django_db
+def test_calculate_daily_iof_with_reference_date(iof_calculator):
+    """Test daily IOF calculation with custom reference date."""
+    # Arrange
+    loan = LoanFactory(
+        amount=Decimal("10000.00"),
+        request_date=date(2024, 1, 1),
+    )
+    reference_date = date(2024, 2, 1)  # 31 days
+
+    # Act
+    result = iof_calculator.calculate_daily_iof(loan, reference_date)
+
+    # Assert
+    # 31 days * 0.0082% = 0.2542% of 10000 = 25.42
+    expected = Decimal("10000.00") * Decimal("0.000082") * Decimal("31")
+    assert result == expected
+    assert result == Decimal("25.42")
+
+
+@pytest.mark.django_db
+def test_calculate_days_end_before_start_returns_zero(iof_calculator):
+    """Test _calculate_days returns 0 when end_date is before start_date."""
+    # Arrange
+    start_date = date(2024, 2, 1)
+    end_date = date(2024, 1, 1)
+
+    # Act
+    result = iof_calculator._calculate_days(start_date, end_date)
+
+    # Assert
+    assert result == 0
+
+
+@pytest.mark.django_db
+@freeze_time("2024-07-01")
+def test_calculate_total_iof(iof_calculator):
+    """Test total IOF calculation (fixed + daily)."""
+    # Arrange
+    loan = LoanFactory(
+        amount=Decimal("10000.00"),
+        request_date=date(2024, 6, 1),  # 30 days ago
+    )
+
+    # Act
+    result = iof_calculator.calculate_total_iof(loan)
+
+    # Assert
+    # Fixed: 10000 * 0.0038 = 38.00
+    # Daily: 10000 * 0.000082 * 30 = 24.60
+    # Total: 38.00 + 24.60 = 62.60
+    fixed_iof = Decimal("38.00")
+    daily_iof = Decimal("24.60")
+    expected = fixed_iof + daily_iof
+    assert result == expected
+    assert result == Decimal("62.60")
+
+
+@pytest.mark.django_db
+@freeze_time("2024-07-01")
+def test_calculate_total_iof_with_reference_date(iof_calculator):
+    """Test total IOF calculation with custom reference date."""
+    # Arrange
+    loan = LoanFactory(
+        amount=Decimal("10000.00"),
+        request_date=date(2024, 1, 1),
+    )
+    reference_date = date(2024, 7, 1)  # 182 days
+
+    # Act
+    result = iof_calculator.calculate_total_iof(loan, reference_date)
+
+    # Assert
+    # Fixed: 10000 * 0.0038 = 38.00
+    # Daily: 10000 * 0.000082 * 182 = 149.24
+    # Total: 38.00 + 149.24 = 187.24
+    fixed_iof = Decimal("38.00")
+    daily_iof = Decimal("10000.00") * Decimal("0.000082") * Decimal("182")
+    expected = fixed_iof + daily_iof
+    assert result == expected

--- a/apps/loans/tests/test_outstanding_balance_calculator_svc.py
+++ b/apps/loans/tests/test_outstanding_balance_calculator_svc.py
@@ -35,9 +35,18 @@ def test_calculate_outstanding_balance_no_payments(
 
     # Assert
     # 2 months of interest: 10000 * (1.025)^2 = 10506.25
-    expected = Decimal("10000.00") * (Decimal("1") + Decimal("0.025")) ** 2
+    # IOF: Fixed (38.00) + Daily (60 days * 0.0082% = 49.20) = 87.20
+    # Total: 10506.25 + 87.20 = 10593.45
+    amount_with_interest = (
+        Decimal("10000.00") * (Decimal("1") + Decimal("0.025")) ** 2
+    )
+    iof_fixed = Decimal("10000.00") * Decimal("0.0038")  # 38.00
+    iof_daily = (
+        Decimal("10000.00") * Decimal("0.000082") * Decimal("60")
+    )  # 49.20
+    total_iof = iof_fixed + iof_daily
+    expected = amount_with_interest + total_iof
     assert result == expected
-    assert result == Decimal("10506.25")
 
 
 @pytest.mark.django_db
@@ -59,14 +68,19 @@ def test_calculate_outstanding_balance_with_payments(
 
     # Assert
     # Amount with interest: 10000 * (1.025)^2 = 10506.25
+    # IOF: Fixed (38.00) + Daily (60 days * 0.0082% = 49.20) = 87.20
     # Total paid: 2000.00
-    # Outstanding: 10506.25 - 2000.00 = 8506.25
+    # Outstanding: 10506.25 + 87.20 - 2000.00 = 8593.45
     amount_with_interest = (
         Decimal("10000.00") * (Decimal("1") + Decimal("0.025")) ** 2
     )
-    expected = amount_with_interest - Decimal("2000.00")
+    iof_fixed = Decimal("10000.00") * Decimal("0.0038")  # 38.00
+    iof_daily = (
+        Decimal("10000.00") * Decimal("0.000082") * Decimal("60")
+    )  # 49.20
+    total_iof = iof_fixed + iof_daily
+    expected = amount_with_interest + total_iof - Decimal("2000.00")
     assert result == expected
-    assert result == Decimal("8506.25")
 
 
 @pytest.mark.django_db
@@ -109,7 +123,15 @@ def test_calculate_outstanding_balance_same_month_returns_principal(
 
     # Assert
     # Same month = 0 months, so no interest
-    assert result == Decimal("10000.00")
+    # IOF: Fixed (38.00) + Daily (14 days * 0.0082% = 11.48) = 49.48
+    # Total: 10000.00 + 49.48 = 10049.48
+    iof_fixed = Decimal("10000.00") * Decimal("0.0038")  # 38.00
+    iof_daily = (
+        Decimal("10000.00") * Decimal("0.000082") * Decimal("14")
+    )  # 11.48
+    total_iof = iof_fixed + iof_daily
+    expected = Decimal("10000.00") + total_iof
+    assert result == expected
 
 
 @pytest.mark.django_db
@@ -130,7 +152,17 @@ def test_calculate_outstanding_balance_with_reference_date(
 
     # Assert
     # 3 months of interest: 10000 * (1.025)^3 = 10768.90625...
-    expected = Decimal("10000.00") * (Decimal("1") + Decimal("0.025")) ** 3
+    # IOF: Fixed (38.00) + Daily (91 days * 0.0082% = 74.62) = 112.62
+    # Total: 10768.90625 + 112.62 = 10881.52625
+    amount_with_interest = (
+        Decimal("10000.00") * (Decimal("1") + Decimal("0.025")) ** 3
+    )
+    iof_fixed = Decimal("10000.00") * Decimal("0.0038")  # 38.00
+    iof_daily = (
+        Decimal("10000.00") * Decimal("0.000082") * Decimal("91")
+    )  # 74.62
+    total_iof = iof_fixed + iof_daily
+    expected = amount_with_interest + total_iof
     assert result == expected
 
 

--- a/apps/loans/tests/test_serializers.py
+++ b/apps/loans/tests/test_serializers.py
@@ -28,6 +28,7 @@ def test_loan_serializer_returns_all_fields():
     assert "request_ip" in data
     assert "total_paid" in data
     assert "remaining_balance" in data
+    assert "iof" in data
     assert "created_at" in data
     assert "updated_at" in data
 
@@ -76,6 +77,29 @@ def test_loan_serializer_get_remaining_balance_calls_use_case(
     # Assert
     mock_use_case.execute.assert_called_once_with(loan)
     assert remaining_balance == 5000.0
+
+
+@pytest.mark.django_db
+@patch("apps.loans.serializers.IOFCalculatorService")
+def test_loan_serializer_get_iof_calls_service(mock_service_class):
+    """Test that get_iof calls IOFCalculatorService."""
+    # Arrange
+    loan = LoanFactory()
+    mock_service = MagicMock()
+    mock_service.calculate_total_iof.return_value = Decimal("185.60")
+    mock_service_class.return_value = mock_service
+
+    serializer = LoanSerializer(loan)
+    serializer.iof_calculator = mock_service
+
+    # Act
+    iof = serializer.get_iof(loan)
+
+    # Assert
+    # calculate_total_iof is called without reference_date (defaults to None)
+    mock_service.calculate_total_iof.assert_called_once()
+    assert mock_service.calculate_total_iof.call_args[0][0] == loan
+    assert iof == 185.60
 
 
 @pytest.mark.django_db
@@ -260,3 +284,4 @@ def test_loan_list_serializer_returns_limited_fields():
     assert "created_at" in data
     assert "total_paid" not in data
     assert "remaining_balance" not in data
+    assert "iof" not in data

--- a/apps/loans/tests/test_views.py
+++ b/apps/loans/tests/test_views.py
@@ -218,8 +218,10 @@ class TestLoanViews(BaseTestCase):
         assert response.status_code == 200
         assert "total_paid" in response.data
         assert "remaining_balance" in response.data
+        assert "iof" in response.data
         assert isinstance(response.data["total_paid"], float)
         assert isinstance(response.data["remaining_balance"], float)
+        assert isinstance(response.data["iof"], float)
 
     def test_list_loans_does_not_include_total_paid_and_remaining_balance(
         self, client, loan_owner
@@ -239,6 +241,7 @@ class TestLoanViews(BaseTestCase):
         for loan_data in response.data["results"]:
             assert "total_paid" not in loan_data
             assert "remaining_balance" not in loan_data
+            assert "iof" not in loan_data
 
     def test_update_loan_critical_fields_with_payments_raises_error(
         self, client, loan_owner

--- a/apps/payments/tests/test_views.py
+++ b/apps/payments/tests/test_views.py
@@ -248,7 +248,7 @@ class TestPaymentViews(BaseTestCase):
         url = reverse("payment-list")
         self.authenticate_user(client, loan_owner)
 
-        # Outstanding balance is ~10506.25 (2 months interest)
+        # Outstanding balance includes interest + IOF (~10593.45 with IOF)
         data = {
             "loan": loan.uuid,
             "payment_date": date(2024, 2, 15).strftime("%Y-%m-%d"),
@@ -351,7 +351,8 @@ class TestPaymentViews(BaseTestCase):
         url = reverse("payment-detail", kwargs={"pk": payment.uuid})
         self.authenticate_user(client, loan_owner)
 
-        # Outstanding balance after first payment is ~9506.25
+        # Outstanding balance after first payment includes interest + IOF
+        # (~8593.45 with IOF)
         update_data = {
             "payment_value": 20000,  # Exceeds outstanding balance
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "credit-track"
-version = "0.4.0"
+version = "0.5.0"
 description = "Loan and payment tracking API with outstanding balance calculation."
 authors = [
     {name = "WillamesCampos",email = "willwjccampos@gmail.com"}


### PR DESCRIPTION
 - **IOFCalculatorService**: Calculates IOF (fixed rate 0.38% + daily rate 0.0082% per day, capped at 3% per year)

- **IOF integration**: IOF included in outstanding balance calculation
- **IOF field**: Added iof field to LoanSerializer (retrieve only)
- **IOF tests**: Comprehensive test coverage for IOF calculation service

### Changed
- OutstandingBalanceCalculatorService: Now includes IOF in balance calculation
- Outstanding balance formula: (Principal + Interest + IOF) - Total Paid
- Updated existing tests to account for IOF in calculations

closes #10 